### PR TITLE
F/files/from subcommand (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ lazy. It's more like a package manager manager.
 ## Usage
 
 ```
-$ cpm [i|r|l|u|U|s|S|c|h] [pkg]...
+$ cpm [i|r|l|u|U|s|S|I|F|f|c|h] [pkg]...
 -> i|install install one or more packages
 -> r|remove  remove one or more packages
 -> l|list    list installed packages
@@ -15,6 +15,8 @@ $ cpm [i|r|l|u|U|s|S|c|h] [pkg]...
 -> s|search  search for a package
 -> S|show    show information about a package
 -> I|info    same as show
+-> F|files   show file list of package
+-> f|from    show package which owns a file
 -> c|clean   clean up leftover files/caches/orphans
 -> h|help    show this message
 ```

--- a/cpm
+++ b/cpm
@@ -6,18 +6,20 @@ phi() {
 }
 
 usage() {
-    >&2 echo "cpm [i|r|l|C|u|U|s|S|I|c|h] [pkg]..."
-    phi i "install" "install one or more packages"
-    phi r "remove " "remove one or more packages"
-    phi l "list   " "list installed packages"
-    phi C "count  " "count installed packages"
-    phi u "update " "update package lists"
-    phi U "upgrade" "upgrade all packages"
-    phi s "search " "search for a package"
-    phi S "show   " "show information about a package"
-    phi I "info   " "same as show"
-    phi c "clean  " "clean up leftover files/caches/orphans"
-    phi h "help   " "show this message"
+    >&2 echo "cpm [i|r|l|C|u|U|s|S|I|F|f|c|h] [pkg]..."
+    phi i  "install" "install one or more packages"
+    phi r  "remove " "remove one or more packages"
+    phi l  "list   " "list installed packages"
+    phi C  "count  " "count installed packages"
+    phi u  "update " "update package lists"
+    phi U  "upgrade" "upgrade all packages"
+    phi s  "search " "search for a package"
+    phi S  "show   " "show information about a package"
+    phi I  "info   " "same as show"
+    phi F  "files  " "show file list of package"
+    phi f  "from   " "show package which owns a file"
+    phi c  "clean  " "clean up leftover files/caches/orphans"
+    phi h  "help   " "show this message"
 }
 
 pem() {
@@ -70,6 +72,12 @@ case "$1" in
             pem "$OP: only one argument is allowed"
             exit 1
         fi
+        ;;
+    F|files)
+        OP='files'
+        ;;
+    f|from)
+        OP='from'
         ;;
     c|clean)
         OP='clean'
@@ -145,6 +153,8 @@ _apk() {
         upgrade) $SUDO apk upgrade;;
         search)  apk search -v "$1";;
         show)    apk search "$1";;
+        from)    apk info --who-owns "$@";;
+        files)   apk info -L "$@";;
         clean)   $SUDO apk cache clean;;
     esac
 }
@@ -152,14 +162,16 @@ _apk() {
 _apt() {
     case "$OP" in
         install) $SUDO apt install "$@";;
-        remove) $SUDO apt remove "$@";;
-        list) apt list --installed;;
-        count) dpkg-query -f '.\n' -W | tot;;
-        update) $SUDO apt update;;
+        remove)  $SUDO apt remove "$@";;
+        list)    apt list --installed;;
+        count)   dpkg-query -f '.\n' -W | tot;;
+        update)  $SUDO apt update;;
         upgrade) $SUDO apt dist-upgrade;;
-        search) apt search "$1";;
-        show) apt show "$1";;
-        clean) $SUDO apt autoremove;;
+        search)  apt search "$1";;
+        show)    apt show "$1";;
+        files)   dpkg -L "$@";;
+        from)    dpkg -S "$@";;
+        clean)   $SUDO apt autoremove;;
     esac
 }
 
@@ -179,7 +191,7 @@ _portage() {
             if has eix; then
                 eix --world | tot
             else
-                >&2 echo "Could not find eix"
+                >&2 pem "Could not find eix"
                 exit 1
             fi
             ;;
@@ -187,107 +199,120 @@ _portage() {
         upgrade) $SUDO emerge -uDU --keep-going --with-bdeps=y @world;;
         search)  emerge -s "$@";;
         show)    emerge -s "$@";;
+        files)   qlist "$@";;
+        from)    qfile "$@";;
         clean)   $SUDO emerge --depclean -v;;
     esac
 }
 
-_dnf() {
-    case "$OP" in
-        install) $SUDO dnf install "$@";;
-        remove) $SUDO dnf remove "$@";;
-        list) dnf list --installed;;
-        count) rpm -qa | tot;;
-        update) $SUDO dnf check-update;;
-        upgrade) $SUDO dnf distro-sync;;
-        search) dnf search "$1";;
-        show) dnf info "$1";;
-        clean) $SUDO dnf autoremove;;
-    esac
-}
+ _dnf() {
+     case "$OP" in
+         install) $SUDO dnf install "$@";;
+         remove)  $SUDO dnf remove "$@";;
+         list)    dnf list --installed;;
+         count)   rpm -qa | tot;;
+         update)  $SUDO dnf check-update;;
+         upgrade) $SUDO dnf distro-sync;;
+         search)  dnf search "$1";;
+         show)    dnf info "$1";;
+         files)   dnf repoquery -l "$@";;
+         from)    dnf provides "$@";;
+         clean)   $SUDO dnf autoremove;;
+     esac
+ }
 
-_nix() {
-    case "$OP" in
-        install) nix-env -iA "$@";;
-        remove) niv-env -e "$@";;
-        list) nix-env -q "$@";;
-        count) nix-env -q | wc -l;;
-        update) nix-channel --update;;
-        upgrade) nix-env -u;;
-        search) nix-env -qa "$@";;
-        show) nix-env -qa --description "$@";;
-        clean) nix-collect-garbage -d;;
-    esac
-}
-
-_pacman() {
-    case "$OP" in
-        install) $SUDO pacman -S "$@";;
-        remove) $SUDO pacman -Rs "$@";;
-        list) pacman -Q;;
-        count) pacman -Q | tot;;
-        update) $SUDO pacman -Sy;;
-        upgrade) $SUDO pacman -Syu;;
-        search) pacman -Ss $1;;
-        show) pacman -Si $1;;
-        clean) $SUDO pacman -Rns $(pacman -Qtdq) && $SUDO pacman -Sc;;
-    esac
-}
+ _pacman() {
+     case "$OP" in
+         install) $SUDO pacman -S "$@";;
+         remove)  $SUDO pacman -Rs "$@";;
+         list)    pacman -Q;;
+         count)   pacman -Q | tot;;
+         update)  $SUDO pacman -Sy;;
+         upgrade) $SUDO pacman -Syu;;
+         search)  pacman -Ss $1;;
+         show)    pacman -Si $1;;
+         files)   pacman -Ql "$@";;
+         from)    pacman -Qo "$@";;
+         clean)   $SUDO pacman -Rns $(pacman -Qtdq) && $SUDO pacman -Sc;;
+     esac
+ }
 
 _urpmi() {
     case "$OP" in
         install) $SUDO urpmi "$@";;
-        remove) $SUDO urpme "$@";;
-        list) rpm -qa;;
-        count) rpm -qa | tot;;
-        update) $SUDO urpmi.update -a;;
+        remove)  $SUDO urpme "$@";;
+        list)    rpm -qa;;
+        count)   rpm -qa | tot;;
+        update)  $SUDO urpmi.update -a;;
         upgrade) $SUDO urpmi --auto-update;;
-        search) urpmq -Y $1;;
-        show) urpmq --summary $1;;
-        clean) $SUDO urpme --auto-orphans;;
+        search)  urpmq -Y $1;;
+        show)    urpmq --summary $1;;
+        f*)      pem "unsupported due to PM being added mid-PR and gk being lazy; please see CONTRIBUTING.md";;
+        clean)   $SUDO urpme --auto-orphans;;
     esac
 }
 
-_macports() {
-    case "$OP" in
-        install) $SUDO port install -c "$@";;
-        remove) $SUDO port uninstall --follow-dependencies "$@";;
-        list) port installed;;
-        count) port installed | tot;;
-        update) $SUDO port sync;;
-        upgrade) $SUDO port selfupdate;;
-        search) port search $1;;
-        show) port info $1;;
-        clean) $SUDO port reclaim;;
-    esac
-}
+ _macports() {
+     case "$OP" in
+         install) $SUDO port install -c "$@";;
+         remove)  $SUDO port uninstall --follow-dependencies "$@";;
+         list)    port installed;;
+         count)   port installed | tot;;
+         update)  $SUDO port sync;;
+         upgrade) $SUDO port selfupdate;;
+         search)  port search $1;;
+         show)    port info $1;;
+         files)   port contents "$@";;
+         from)    port provides "$@";;
+         clean)   $SUDO port reclaim;;
+     esac
+ }
 
-_xbps() {
-    case "$OP" in
-        install) $SUDO xbps-install "$@";;
-        remove) $SUDO xbps-remove -R "$@";;
-        list) xbps-query -l;;
-        count) xbps-query -l | tot;;
-        update) $SUDO xbps-install -S;;
-        upgrade) $SUDO xbps-install -Su xbps && $SUDO xbps-install -u;;
-        search) xbps-query -s "$1" --repository;;
-        show) xbps-query -S "$1" --repository;;
-        clean) $SUDO xbps-remove -ROo;;
-    esac
-}
+ _xbps() {
+     case "$OP" in
+         install) $SUDO xbps-install "$@";;
+         remove)  $SUDO xbps-remove -R "$@";;
+         list)    xbps-query -l;;
+         count)   xbps-query -l | tot;;
+         update)  $SUDO xbps-install -S;;
+         upgrade) $SUDO xbps-install -Su xbps && $SUDO xbps-install -u;;
+         search)  xbps-query -s "$1" --repository;;
+         show)    xbps-query -S "$1" --repository;;
+         files)   xbps-query -f "$1" --repository;;
+         from)    xbps-query -o "$1" --repository;;
+         clean)   $SUDO xbps-remove -ROo;;
+     esac
+ }
 
 _slackpkg() {
     case "$OP" in
         install) $SUDO slackpkg install "$@";;
-        remove) $SUDO slackpkg remove "$@";;
-        list) flist /var/log/packages;;
-        count) fcount /var/log/packages/*;;
-        update) $SUDO slackpkg update gpg && slackpkg update;;
+        remove)  $SUDO slackpkg remove "$@";;
+        list)    flist /var/log/packages;;
+        count)   fcount /var/log/packages/*;;
+        update)  $SUDO slackpkg update gpg && slackpkg update;;
         upgrade) $SUDO slackpkg upgrade-all;;
-        search) slackpkg search $1;;
-        show) slackpkg info $1;;
-        clean) $SUDO slackpkg clean-system;;
+        search)  slackpkg search $1;;
+        show)    slackpkg info $1;;
+        f*)      pem "unsupported due to PM being added mid-PR and gk being lazy; please see CONTRIBUTING.md";;
+        clean)   $SUDO slackpkg clean-system;;
     esac
 }
+
+ _nix() {
+     case "$OP" in
+         install) nix-env -iA "$@";;
+         remove)  niv-env -e "$@";;
+         list)    nix-env -q "$@";;
+         count)   nix-env -q | wc -l;;
+         update)  nix-channel --update;;
+         upgrade) nix-env -u;;
+         search)  nix-env -qa "$@";;
+         show)    nix-env -qa --description "$@";;
+         f*)      pem "unsupported: this feature is functionally useless in this PM";;
+         clean)   nix-collect-garbage -d;;
+     esac
+ }
 
 if   has apk; then
     # alpine/adelie
@@ -301,9 +326,6 @@ elif has emerge; then
 elif has dnf; then
     # fedora
     _dnf "$@"
-elif has nix; then
-    # nix
-    _nix "$@"
 elif has pacman-key; then
     # arch/manjaro
     _pacman "$@"
@@ -319,6 +341,9 @@ elif has xbps-install; then
 elif has slackpkg; then
     # slackware
     _slackpkg "$@"
+elif has nix; then
+    # global/nixos
+    _nix "$@"
 elif has brew; then
     pem "Homebrew is not supported [wontfix]"
     exit 1


### PR DESCRIPTION
* New subcommand: f

files   show file list of package
from    show package which owns a file

Show file list of package, or the package which owns a file.

notes:
 - qfile/qlist & equery aren't pre-installed on gentoo, equery might be
    a bit more common, but the q* commands are faster.
 - slackpkg is unsupported due to being added mid-PR and gk being lazy
 - nix is intentionally unsupported as this feature is functionally useless in it
 - won't work with symlinks due to PM limitations (if /bin -> /usr/bin,
    then /bin/file won't work)

other changes:
 - move nix below native package managers
 - semi-consistently aligned case statements (apk & emerge were aligned
    previously, others weren't)

* Don't autodetect files/from